### PR TITLE
Fix broken assets on custom domain

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,6 @@ import tailwind from '@astrojs/tailwind';
 import sitemap from '@astrojs/sitemap';
 
 export default defineConfig({
-  site: 'https://perceptumnl.github.io',
-  base: '/iga-website/',
+  site: 'https://igamarketing.com',
   integrations: [tailwind(), sitemap()],
 });

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://perceptumnl.github.io/iga-website/sitemap-index.xml
+Sitemap: https://igamarketing.com/sitemap-index.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,11 +1,11 @@
 {
   "name": "IGA — Innovative Growth Agency",
   "short_name": "IGA",
-  "start_url": "/iga-website/",
+  "start_url": "/",
   "display": "standalone",
   "background_color": "#FFFFFF",
   "theme_color": "#95BCF8",
   "icons": [
-    { "src": "/iga-website/favicon.svg", "sizes": "any", "type": "image/svg+xml" }
+    { "src": "/favicon.svg", "sizes": "any", "type": "image/svg+xml" }
   ]
 }

--- a/src/content/insights/full-funnel-revenue-system.md
+++ b/src/content/insights/full-funnel-revenue-system.md
@@ -115,4 +115,4 @@ You don't need more leads. You need a system.
 
 ---
 
-*Want to find out where your funnel is leaking? [Book a strategy session](/iga-website/contact) — we'll map your full funnel and identify the highest-impact improvements.*
+*Want to find out where your funnel is leaking? [Book a strategy session](/contact) — we'll map your full funnel and identify the highest-impact improvements.*

--- a/src/content/insights/how-to-build-b2b-lead-qualification-system.md
+++ b/src/content/insights/how-to-build-b2b-lead-qualification-system.md
@@ -136,4 +136,4 @@ You don't need more leads. You need better ones. And that requires a system.
 
 ---
 
-*Want to build a lead qualification system for your business? [Let's talk](/iga-website/contact) — we'll analyze your current pipeline and show you where qualified leads are falling through.*
+*Want to build a lead qualification system for your business? [Let's talk](/contact) — we'll analyze your current pipeline and show you where qualified leads are falling through.*

--- a/src/content/insights/marketing-for-long-sales-cycles.md
+++ b/src/content/insights/marketing-for-long-sales-cycles.md
@@ -121,4 +121,4 @@ This is not a quick win. It is a structural advantage that grows stronger over t
 
 ---
 
-*Selling to enterprise accounts with long sales cycles? [Let's build your ABM system](/iga-website/contact) — we'll map your target accounts and design the engagement strategy.*
+*Selling to enterprise accounts with long sales cycles? [Let's build your ABM system](/contact) — we'll map your target accounts and design the engagement strategy.*

--- a/src/content/insights/revenue-engineering-shift-from-campaigns-to-systems.md
+++ b/src/content/insights/revenue-engineering-shift-from-campaigns-to-systems.md
@@ -93,4 +93,4 @@ If it's not, more campaigns won't fix it. Better systems will.
 
 ---
 
-*Want to understand what a revenue system looks like for your business? [Schedule a strategy session](/iga-website/contact) — we'll audit your current setup and identify where the system breaks down.*
+*Want to understand what a revenue system looks like for your business? [Schedule a strategy session](/contact) — we'll audit your current setup and identify where the system breaks down.*

--- a/src/content/insights/why-most-b2b-marketing-fails.md
+++ b/src/content/insights/why-most-b2b-marketing-fails.md
@@ -80,4 +80,4 @@ That is what revenue engineering looks like. And that is what we do.
 
 ---
 
-*Ready to audit your marketing-revenue connection? [Schedule a strategy session](/iga-website/contact) and we'll map out where your revenue is leaking.*
+*Ready to audit your marketing-revenue connection? [Schedule a strategy session](/contact) and we'll map out where your revenue is leaking.*

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,7 +6,7 @@ interface Props {
 }
 
 const base = import.meta.env.BASE_URL;
-const siteUrl = import.meta.env.SITE || 'https://perceptumnl.github.io';
+const siteUrl = import.meta.env.SITE || 'https://igamarketing.com';
 const { title, description = 'IGA — Revenue engineering partner. We build systems that generate leads, improve conversion, and scale your business.', ogImage = `${base}og-image.png` } = Astro.props;
 const canonicalUrl = new URL(Astro.url.pathname, siteUrl).href;
 ---

--- a/src/pages/hero.astro
+++ b/src/pages/hero.astro
@@ -11,8 +11,8 @@ const base = import.meta.env.BASE_URL;
     "@context": "https://schema.org",
     "@type": "Organization",
     "name": "IGA — Innovative Growth Agency",
-    "url": "https://perceptumnl.github.io/iga-website/",
-    "logo": "https://perceptumnl.github.io/iga-website/logos/logo-iga-black.png",
+    "url": "https://igamarketing.com/",
+    "logo": "https://igamarketing.com/logos/logo-iga-black.png",
     "description": "Revenue engineering partner focused on helping businesses generate high quality leads and scale efficiently through structured marketing systems.",
     "foundingLocation": { "@type": "Place", "name": "St. Maarten" },
     "knowsAbout": ["Revenue Engineering", "B2B Marketing", "Lead Generation", "Marketing Systems", "Conversion Optimization"]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,8 +11,8 @@ const base = import.meta.env.BASE_URL;
     "@context": "https://schema.org",
     "@type": "Organization",
     "name": "IGA — Innovative Growth Agency",
-    "url": "https://perceptumnl.github.io/iga-website/",
-    "logo": "https://perceptumnl.github.io/iga-website/logos/logo-iga-black.png",
+    "url": "https://igamarketing.com/",
+    "logo": "https://igamarketing.com/logos/logo-iga-black.png",
     "description": "Revenue engineering partner focused on helping businesses generate high quality leads and scale efficiently through structured marketing systems.",
     "foundingLocation": { "@type": "Place", "name": "St. Maarten" },
     "knowsAbout": ["Revenue Engineering", "B2B Marketing", "Lead Generation", "Marketing Systems", "Conversion Optimization"]


### PR DESCRIPTION
The Astro config was still built for the GitHub Pages project URL
(https://perceptumnl.github.io/iga-website/), so every CSS/JS/image URL
in the output was prefixed with /iga-website/. On the new custom domain
(igamarketing.com, served from root) those paths 404, leaving the page
unstyled.

- astro.config: drop base, point site at https://igamarketing.com
- site.webmanifest, robots.txt: root-relative paths and new sitemap URL
- hero.astro, index.astro JSON-LD: use igamarketing.com for url/logo
- Layout.astro: update SITE fallback to igamarketing.com
- insights markdown: rewrite /iga-website/contact links to /contact